### PR TITLE
feat: implementa extensao para lidar com CORS

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask
 from flask_migrate import Migrate
 from flask_login import LoginManager
+from flask_cors import CORS
 from flasgger import Swagger
 
 from datetime import timedelta
@@ -11,6 +12,9 @@ from database import init_database
 app = Flask(__name__)
 app.secret_key = config('SECRET_KEY')
 app.config['TIMEZONE'] = timedelta(hours=-3)
+
+# Configura CORS para todo o app; 
+CORS(app, origins=['*']) # permite todas as origens
 
 
 # Config Swagger Doc
@@ -35,10 +39,10 @@ from models.agendamento import Agendamento
 ## Registra as rotas do app
 from routes import index, usuario, auth, agendamento
 
-app.register_blueprint(index.index_bp, url_prefix='/')
-app.register_blueprint(usuario.usuario_bp, url_prefix='/')
-app.register_blueprint(auth.auth_bp, url_prefix='/')
-app.register_blueprint(agendamento.agendamento_bp, url_prefix='/')
+app.register_blueprint(index.index_bp, url_prefix='/api/v1')
+app.register_blueprint(usuario.usuario_bp, url_prefix='/api/v1')
+app.register_blueprint(auth.auth_bp, url_prefix='/api/v1')
+app.register_blueprint(agendamento.agendamento_bp, url_prefix='/api/v1')
 
 
 # Login manager

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ attrs==22.2.0
 click==8.1.3
 flasgger==0.9.5
 Flask==2.2.3
+Flask-Cors==3.0.10
 Flask-Login==0.6.2
 Flask-Migrate==4.0.4
 Flask-SQLAlchemy==3.0.3


### PR DESCRIPTION
### O que este PR está fazendo?
- Implementa a extensão Flask-CORS para lidar com CORS do lado do servidor, para que o frontend consiga realizar integração com as APIs
- Modifica o prefixo do endpoint do backend para `/api/v1`, assim a URL base completa do backend ficará: `http://127.0.0.1:5000/api/v1`